### PR TITLE
fix(segmented-control): brighten dark-mode active background (fixes #65)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aniui/cli",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aniui/cli",
-      "version": "0.2.25",
+      "version": "0.2.26",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aniui/cli",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Beautiful React Native components. Copy. Paste. Ship.",
   "license": "MIT",
   "author": "Anish",

--- a/components/ui/segmented-control.tsx
+++ b/components/ui/segmented-control.tsx
@@ -35,7 +35,7 @@ export function SegmentedControl<T extends string | number = string>({
   ...rest
 }: SegmentedControlProps<T>) {
   const dark = useColorScheme() === "dark";
-  const activeBg = dark ? "#27272a" : "#ffffff";
+  const activeBg = dark ? "#37373a" : "#ffffff";
   const activeFg = dark ? "#fafafa" : "#09090b";
   const inactiveFg = dark ? "#a1a1aa" : "#71717a";
   const disabledFg = dark ? "#52525b" : "#d4d4d8";

--- a/docs/app/docs/changelog/page.tsx
+++ b/docs/app/docs/changelog/page.tsx
@@ -26,12 +26,21 @@ const typeBadge: Record<ChangeType, { label: string; className: string }> = {
 
 const releases: Release[] = [
   {
+    version: "0.2.26",
+    date: "2026-05-08",
+    title: "SegmentedControl Dark-Mode Contrast",
+    changes: [
+      { type: "fix", text: "SegmentedControl: bumped the dark-mode active segment background from #27272a to #37373a so it visibly elevates above the muted track instead of blending in.", link: "/docs/segmented-control" },
+    ],
+  },
+  {
     version: "0.2.25",
     date: "2026-05-07",
     title: "NativeWind v5 Crash Fix & Calmer Animations",
     changes: [
       { type: "fix", text: "NumberInput: works around a NativeWind v5 preview cssInterop bug that crashed with 'path.split is not a function' when text-center was used on a TextInput. Center alignment is now passed via the textAlign prop instead of a className.", link: "/docs/number-input" },
       { type: "fix", text: "Animation presets: zoomIn (used by AlertDialog) and fadeInDown/fadeInUp (used by Accordion and Collapsible) no longer overshoot. Dropped springify() in favor of a clean ease-out so dialogs and expanding content settle without bounce. Toast and ConnectionBanner keep their springy feel — bounce there reads as attention.", link: "/docs/animate" },
+      { type: "fix", text: "SegmentedControl: bumped the dark-mode active segment background from #27272a to #37373a so it visibly elevates above the muted track instead of blending in.", link: "/docs/segmented-control" },
     ],
   },
   {

--- a/examples/bare_rn_starter/components/ui/segmented-control.tsx
+++ b/examples/bare_rn_starter/components/ui/segmented-control.tsx
@@ -35,7 +35,7 @@ export function SegmentedControl<T extends string | number = string>({
   ...rest
 }: SegmentedControlProps<T>) {
   const dark = useColorScheme() === "dark";
-  const activeBg = dark ? "#27272a" : "#ffffff";
+  const activeBg = dark ? "#37373a" : "#ffffff";
   const activeFg = dark ? "#fafafa" : "#09090b";
   const inactiveFg = dark ? "#a1a1aa" : "#71717a";
   const disabledFg = dark ? "#52525b" : "#d4d4d8";

--- a/examples/expo-55-starter/components/ui/segmented-control.tsx
+++ b/examples/expo-55-starter/components/ui/segmented-control.tsx
@@ -35,7 +35,7 @@ export function SegmentedControl<T extends string | number = string>({
   ...rest
 }: SegmentedControlProps<T>) {
   const dark = useColorScheme() === "dark";
-  const activeBg = dark ? "#27272a" : "#ffffff";
+  const activeBg = dark ? "#37373a" : "#ffffff";
   const activeFg = dark ? "#fafafa" : "#09090b";
   const inactiveFg = dark ? "#a1a1aa" : "#71717a";
   const disabledFg = dark ? "#52525b" : "#d4d4d8";

--- a/examples/expo-starter/components/ui/segmented-control.tsx
+++ b/examples/expo-starter/components/ui/segmented-control.tsx
@@ -35,7 +35,7 @@ export function SegmentedControl<T extends string | number = string>({
   ...rest
 }: SegmentedControlProps<T>) {
   const dark = useColorScheme() === "dark";
-  const activeBg = dark ? "#27272a" : "#ffffff";
+  const activeBg = dark ? "#37373a" : "#ffffff";
   const activeFg = dark ? "#fafafa" : "#09090b";
   const inactiveFg = dark ? "#a1a1aa" : "#71717a";
   const disabledFg = dark ? "#52525b" : "#d4d4d8";

--- a/examples/with-uniwind/components/ui/segmented-control.tsx
+++ b/examples/with-uniwind/components/ui/segmented-control.tsx
@@ -35,7 +35,7 @@ export function SegmentedControl<T extends string | number = string>({
   ...rest
 }: SegmentedControlProps<T>) {
   const dark = useColorScheme() === "dark";
-  const activeBg = dark ? "#27272a" : "#ffffff";
+  const activeBg = dark ? "#37373a" : "#ffffff";
   const activeFg = dark ? "#fafafa" : "#09090b";
   const inactiveFg = dark ? "#a1a1aa" : "#71717a";
   const disabledFg = dark ? "#52525b" : "#d4d4d8";


### PR DESCRIPTION
## Description
Brief description of what this PR does.

## Type of Change
- [x] Bug fix
- [ ] New component
- [ ] Enhancement to existing component
- [ ] CLI change
- [ ] Documentation
- [ ] Other

## Component Checklist (if adding/modifying a component)
- [ ] Single file, under 80 lines
- [ ] Named export only (no default export)
- [ ] No `StyleSheet.create()` — NativeWind `className` only
- [ ] Imports `cn` from `@/lib/utils`
- [ ] `className` prop supported
- [ ] `...props` spread last
- [ ] `accessibilityRole` set on interactive elements
- [ ] Strict TypeScript — no `any` types
- [ ] Registry entry added in `cli/src/registry.ts`

## Testing
- [ ] `cd cli && npm test` passes
- [ ] Tested on iOS Simulator
- [ ] Tested on Android Emulator
- [ ] Dark mode works correctly

## Documentation
- [ ] Docs page created (if new component)
- [ ] Web preview component created (if new component)
- [ ] Sidebar/navbar updated (if new component)

## Screenshots
If applicable, add screenshots or GIFs showing the component.
