### PR TITLE
bug: Text in Input on iOS is not centered vertically

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -68,7 +68,7 @@ export const Input = React.forwardRef<
       {leadingIcon && <View className="me-2">{leadingIcon}</View>}
       <TextInput
         ref={ref}
-        className="flex-1 text-foreground p-0 text-base"
+        className="flex-1 text-foreground p-0"
         placeholderTextColor={dark ? "#a1a1aa" : "#71717a"}
         keyboardAppearance={dark ? "dark" : "light"}
         selectionColor={caret}


### PR DESCRIPTION
## Description
Input text on iOS is not centered vertically

## Type of Change
- [ ] Bug fix
- [ ] New component
- [x] Enhancement to existing component
- [ ] CLI change
- [ ] Documentation
- [ ] Other

## Component Checklist (if adding/modifying a component)
- [ ] Single file, under 80 lines
- [ ] Named export only (no default export)
- [ ] No `StyleSheet.create()` — NativeWind `className` only
- [ ] Imports `cn` from `@/lib/utils`
- [ ] `className` prop supported
- [ ] `...props` spread last
- [ ] `accessibilityRole` set on interactive elements
- [ ] Strict TypeScript — no `any` types
- [ ] Registry entry added in `cli/src/registry.ts`

## Testing
- [ ] `cd cli && npm test` passes
- [ ] Tested on iOS Simulator
- [ ] Tested on Android Emulator
- [ ] Dark mode works correctly

## Documentation
- [ ] Docs page created (if new component)
- [ ] Web preview component created (if new component)
- [ ] Sidebar/navbar updated (if new component)

## Screenshots
<img width="1199" height="287" alt="微信图片_20260519104251_104_270" src="https://github.com/user-attachments/assets/193b7ab5-a860-49ea-ae06-7dacc4c48f0b" />

