### PR TITLE
fix(docs): page-transition leaving routes stuck at opacity 0

### DIFF
--- a/docs/components/docs-page-transition.tsx
+++ b/docs/components/docs-page-transition.tsx
@@ -2,23 +2,25 @@
 
 import React from "react";
 import { usePathname } from "next/navigation";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 
+// Plain keyed motion.div — re-mounts on route change and replays the enter
+// animation. Intentionally NOT wrapped in AnimatePresence mode="wait":
+// with the App Router, exit-then-stream-enter races with React Server
+// Components and occasionally leaves the new page stuck at opacity 0
+// until a hard refresh.
 export function DocsPageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const prefersReducedMotion = useReducedMotion();
 
   return (
-    <AnimatePresence mode="wait" initial={false}>
-      <motion.div
-        key={pathname}
-        initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-        transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-      >
-        {children}
-      </motion.div>
-    </AnimatePresence>
+    <motion.div
+      key={pathname}
+      initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </motion.div>
   );
 }


### PR DESCRIPTION
Navigating between /docs/* pages would occasionally land a blank page until a hard refresh. Root cause: DocsPageTransition wrapped its motion.div in AnimatePresence mode="wait" + key={pathname}. Under the App Router, the exit animation finishes, then React Server Components stream the new page in — and the enter animation sometimes doesn't fire after the stream lands, leaving the page stuck at the initial { opacity: 0, y: 12 }.

Drop AnimatePresence and just use a plain keyed motion.div. The new pathname triggers an unmount/remount, the enter animation always runs, no race with the RSC stream. Exit animation goes away, but with mode="wait" it was visually subtle anyway.

Comment in the file explains why so the AnimatePresence wrapper doesn't get re-added later.

## Description
Brief description of what this PR does.

## Type of Change
- [ ] Bug fix
- [ ] New component
- [ ] Enhancement to existing component
- [ ] CLI change
- [ ] Documentation
- [ ] Other

## Component Checklist (if adding/modifying a component)
- [ ] Single file, under 80 lines
- [ ] Named export only (no default export)
- [ ] No `StyleSheet.create()` — NativeWind `className` only
- [ ] Imports `cn` from `@/lib/utils`
- [ ] `className` prop supported
- [ ] `...props` spread last
- [ ] `accessibilityRole` set on interactive elements
- [ ] Strict TypeScript — no `any` types
- [ ] Registry entry added in `cli/src/registry.ts`

## Testing
- [ ] `cd cli && npm test` passes
- [ ] Tested on iOS Simulator
- [ ] Tested on Android Emulator
- [ ] Dark mode works correctly

## Documentation
- [ ] Docs page created (if new component)
- [ ] Web preview component created (if new component)
- [ ] Sidebar/navbar updated (if new component)

## Screenshots
If applicable, add screenshots or GIFs showing the component.
