### PR TITLE
perf(docs): prefetch links on intent to cut Vercel edge requests

### DIFF
--- a/docs/app/blocks/page.tsx
+++ b/docs/app/blocks/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
+import { PrefetchLink } from "@/components/prefetch-link";
 import { blockCategories } from "@/components/block-nav";
 
 const categoryIcons: Record<string, React.ReactNode> = {
@@ -52,7 +52,7 @@ export default function BlocksPage() {
 
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {category.blocks.map((block) => (
-              <Link
+              <PrefetchLink
                 key={block.href}
                 href={block.href}
                 className="group flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-all hover:border-primary/30 hover:shadow-sm"
@@ -76,7 +76,7 @@ export default function BlocksPage() {
                 >
                   <polyline points="9 18 15 12 9 6" />
                 </svg>
-              </Link>
+              </PrefetchLink>
             ))}
           </div>
         </section>

--- a/docs/components/block-nav.tsx
+++ b/docs/components/block-nav.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { PrefetchLink } from "./prefetch-link";
 
 const blockCategories = [
   {
@@ -115,12 +115,12 @@ export function BlockNav() {
     <div className="mb-8" ref={ref}>
       {/* Breadcrumb + Selector Row */}
       <div className="flex items-center gap-2 mb-3">
-        <Link
+        <PrefetchLink
           href="/blocks"
           className="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           Blocks
-        </Link>
+        </PrefetchLink>
         <span className="text-muted-foreground/40">/</span>
         {current && (
           <span className="text-xs text-muted-foreground bg-muted rounded-full px-2 py-0.5">
@@ -161,7 +161,7 @@ export function BlockNav() {
                   {cat.blocks.map((block) => {
                     const isActive = pathname === block.href;
                     return (
-                      <Link
+                      <PrefetchLink
                         key={block.href}
                         href={block.href}
                         className={cn(
@@ -177,7 +177,7 @@ export function BlockNav() {
                             <CheckIcon />
                           </span>
                         )}
-                      </Link>
+                      </PrefetchLink>
                     );
                   })}
                 </div>
@@ -206,7 +206,7 @@ export function BlockPagination() {
   return (
     <div className="mt-16 pt-6 border-t border-border flex items-stretch gap-3">
       {prev ? (
-        <Link
+        <PrefetchLink
           href={prev.href}
           className="group flex-1 flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-all hover:border-primary/30 hover:shadow-sm"
         >
@@ -221,12 +221,12 @@ export function BlockPagination() {
               {prev.title}
             </span>
           </div>
-        </Link>
+        </PrefetchLink>
       ) : (
         <div className="flex-1" />
       )}
       {next ? (
-        <Link
+        <PrefetchLink
           href={next.href}
           className="group flex-1 flex items-center justify-end gap-3 rounded-xl border border-border bg-card p-4 transition-all hover:border-primary/30 hover:shadow-sm text-right"
         >
@@ -241,7 +241,7 @@ export function BlockPagination() {
           <span className="text-muted-foreground group-hover:text-primary transition-colors">
             <ArrowRight />
           </span>
-        </Link>
+        </PrefetchLink>
       ) : (
         <div className="flex-1" />
       )}

--- a/docs/components/chart-nav.tsx
+++ b/docs/components/chart-nav.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { PrefetchLink } from "./prefetch-link";
 
 const chartTypes = [
   { title: "Area Chart", href: "/charts/area-chart" },
@@ -69,12 +69,12 @@ export function ChartNav() {
   return (
     <div className="mb-8" ref={ref}>
       <div className="flex items-center gap-2 mb-3">
-        <Link
+        <PrefetchLink
           href="/charts"
           className="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           Charts
-        </Link>
+        </PrefetchLink>
         <span className="text-muted-foreground/40">/</span>
       </div>
 
@@ -101,7 +101,7 @@ export function ChartNav() {
               {chartTypes.map((chart) => {
                 const isActive = pathname === chart.href;
                 return (
-                  <Link
+                  <PrefetchLink
                     key={chart.href}
                     href={chart.href}
                     className={cn(
@@ -117,7 +117,7 @@ export function ChartNav() {
                         <CheckIcon />
                       </span>
                     )}
-                  </Link>
+                  </PrefetchLink>
                 );
               })}
             </div>
@@ -144,7 +144,7 @@ export function ChartPagination() {
   return (
     <div className="mt-16 pt-6 border-t border-border flex items-stretch gap-3">
       {prev ? (
-        <Link
+        <PrefetchLink
           href={prev.href}
           className="group flex-1 flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-all hover:border-primary/30 hover:shadow-sm"
         >
@@ -159,12 +159,12 @@ export function ChartPagination() {
               {prev.title}
             </span>
           </div>
-        </Link>
+        </PrefetchLink>
       ) : (
         <div className="flex-1" />
       )}
       {next ? (
-        <Link
+        <PrefetchLink
           href={next.href}
           className="group flex-1 flex items-center justify-end gap-3 rounded-xl border border-border bg-card p-4 transition-all hover:border-primary/30 hover:shadow-sm text-right"
         >
@@ -179,7 +179,7 @@ export function ChartPagination() {
           <span className="text-muted-foreground group-hover:text-primary transition-colors">
             <ArrowRight />
           </span>
-        </Link>
+        </PrefetchLink>
       ) : (
         <div className="flex-1" />
       )}

--- a/docs/components/docs-pagination.tsx
+++ b/docs/components/docs-pagination.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { PrefetchLink } from "./prefetch-link";
 import { gettingStartedItems, componentItems, type NavItem } from "@/lib/nav-data";
 
 const allPages: NavItem[] = [...gettingStartedItems.filter(i => i.href !== "/create"), ...componentItems];
@@ -18,22 +18,22 @@ export function DocsPagination() {
   return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 border-t border-border pt-6 mt-10">
       {prev ? (
-        <Link
+        <PrefetchLink
           href={prev.href}
           className="group flex flex-col items-start gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <span className="text-xs text-muted-foreground/60">Previous</span>
           <span className="font-medium">← {prev.title}</span>
-        </Link>
+        </PrefetchLink>
       ) : <div />}
       {next ? (
-        <Link
+        <PrefetchLink
           href={next.href}
           className="group flex flex-col items-end gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <span className="text-xs text-muted-foreground/60">Next</span>
           <span className="font-medium">{next.title} →</span>
-        </Link>
+        </PrefetchLink>
       ) : <div />}
     </div>
   );

--- a/docs/components/navbar.tsx
+++ b/docs/components/navbar.tsx
@@ -2,8 +2,8 @@
 
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import { useTheme } from "./theme-provider";
+import { PrefetchLink } from "./prefetch-link";
 import { gettingStartedItems, componentItems, chartItems, blockItems } from "@/lib/nav-data";
 import { CommandSearch } from "./command-search";
 
@@ -85,31 +85,31 @@ export function Navbar() {
             {mobileOpen ? <CloseIcon /> : <MenuIcon />}
           </button>
 
-          <Link href="/" className="flex items-center">
+          <PrefetchLink href="/" className="flex items-center">
             <Image
               src={theme === "dark" ? "/logo-dark.png" : "/logo-light.png"}
               alt="AniUI"
               width={90}
               height={90}
             />
-          </Link>
+          </PrefetchLink>
 
           <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
-            <Link href="/docs" className="text-muted-foreground hover:text-foreground transition-colors">
+            <PrefetchLink href="/docs" className="text-muted-foreground hover:text-foreground transition-colors">
               Docs
-            </Link>
-            <Link href="/docs/accordion" className="text-muted-foreground hover:text-foreground transition-colors">
+            </PrefetchLink>
+            <PrefetchLink href="/docs/accordion" className="text-muted-foreground hover:text-foreground transition-colors">
               Components
-            </Link>
-            <Link href="/charts" className="text-muted-foreground hover:text-foreground transition-colors">
+            </PrefetchLink>
+            <PrefetchLink href="/charts" className="text-muted-foreground hover:text-foreground transition-colors">
               Charts
-            </Link>
-            <Link href="/blocks" className="text-muted-foreground hover:text-foreground transition-colors">
+            </PrefetchLink>
+            <PrefetchLink href="/blocks" className="text-muted-foreground hover:text-foreground transition-colors">
               Blocks
-            </Link>
-            <Link href="/create" className="text-muted-foreground hover:text-foreground transition-colors">
+            </PrefetchLink>
+            <PrefetchLink href="/create" className="text-muted-foreground hover:text-foreground transition-colors">
               Create
-            </Link>
+            </PrefetchLink>
             <a
               href="https://pro.aniui.dev"
               target="_blank"
@@ -172,32 +172,32 @@ export function Navbar() {
               </span>
             </a>
             {gettingStartedItems.map((item) => (
-              <Link key={item.href} href={item.href} className="block text-sm text-muted-foreground hover:text-foreground" onClick={() => setMobileOpen(false)}>
+              <PrefetchLink key={item.href} href={item.href} className="block text-sm text-muted-foreground hover:text-foreground" onClick={() => setMobileOpen(false)}>
                 {item.title}
-              </Link>
+              </PrefetchLink>
             ))}
             <div className="border-t border-border pt-4 mt-4">
               <p className="text-xs font-semibold text-foreground mb-2">Components</p>
               {componentItems.map((item, i) => (
-                <Link key={item.href} href={item.href} className={`block text-sm text-muted-foreground hover:text-foreground${i > 0 ? " mt-2" : ""}`} onClick={() => setMobileOpen(false)}>
+                <PrefetchLink key={item.href} href={item.href} className={`block text-sm text-muted-foreground hover:text-foreground${i > 0 ? " mt-2" : ""}`} onClick={() => setMobileOpen(false)}>
                   {item.title}
-                </Link>
+                </PrefetchLink>
               ))}
             </div>
             <div className="border-t border-border pt-4 mt-4">
               <p className="text-xs font-semibold text-foreground mb-2">Charts</p>
               {chartItems.map((item, i) => (
-                <Link key={item.href} href={item.href} className={`block text-sm text-muted-foreground hover:text-foreground${i > 0 ? " mt-2" : ""}`} onClick={() => setMobileOpen(false)}>
+                <PrefetchLink key={item.href} href={item.href} className={`block text-sm text-muted-foreground hover:text-foreground${i > 0 ? " mt-2" : ""}`} onClick={() => setMobileOpen(false)}>
                   {item.title}
-                </Link>
+                </PrefetchLink>
               ))}
             </div>
             <div className="border-t border-border pt-4 mt-4">
               <p className="text-xs font-semibold text-foreground mb-2">Blocks</p>
               {blockItems.map((item, i) => (
-                <Link key={item.href} href={item.href} className={`block text-sm text-muted-foreground hover:text-foreground${i > 0 ? " mt-2" : ""}`} onClick={() => setMobileOpen(false)}>
+                <PrefetchLink key={item.href} href={item.href} className={`block text-sm text-muted-foreground hover:text-foreground${i > 0 ? " mt-2" : ""}`} onClick={() => setMobileOpen(false)}>
                   {item.title}
-                </Link>
+                </PrefetchLink>
               ))}
             </div>
           </nav>

--- a/docs/components/prefetch-link.tsx
+++ b/docs/components/prefetch-link.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+// Survives route changes so a link is only ever warmed once per page load.
+const warmed = new Set<string>();
+
+type PrefetchLinkProps = Omit<
+  React.ComponentProps<typeof Link>,
+  "href" | "prefetch"
+> & {
+  href: string;
+};
+
+/**
+ * next/link prefetches every link that scrolls into the viewport, and because
+ * every docs route is statically generated that means a *full* RSC payload per
+ * link. The sidebar alone holds 133 links, so one scroll can burn 133 Vercel
+ * edge requests. This warms on intent instead, which keeps navigation instant
+ * while only paying for routes the user actually aims at.
+ */
+export function PrefetchLink({
+  href,
+  onMouseEnter,
+  onFocus,
+  onTouchStart,
+  ...props
+}: PrefetchLinkProps) {
+  const router = useRouter();
+
+  function warm() {
+    if (warmed.has(href)) return;
+    warmed.add(href);
+    router.prefetch(href);
+  }
+
+  return (
+    <Link
+      href={href}
+      prefetch={false}
+      onMouseEnter={(e) => {
+        warm();
+        onMouseEnter?.(e);
+      }}
+      onFocus={(e) => {
+        warm();
+        onFocus?.(e);
+      }}
+      onTouchStart={(e) => {
+        warm();
+        onTouchStart?.(e);
+      }}
+      {...props}
+    />
+  );
+}

--- a/docs/components/sidebar.tsx
+++ b/docs/components/sidebar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion, type Variants } from "motion/react";
 import { cn } from "@/lib/utils";
+import { PrefetchLink } from "./prefetch-link";
 import { sidebarSections } from "@/lib/nav-data";
 
 const sectionContainer: Variants = {
@@ -57,7 +57,7 @@ export function Sidebar() {
                           }
                         />
                       )}
-                      <Link
+                      <PrefetchLink
                         href={item.href}
                         className={cn(
                           "relative block rounded-md px-3 py-1.5 text-sm transition-colors",
@@ -67,7 +67,7 @@ export function Sidebar() {
                         )}
                       >
                         {item.title}
-                      </Link>
+                      </PrefetchLink>
                     </motion.li>
                   );
                 })}

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -5,6 +5,13 @@ const nextConfig: NextConfig = {
   pageExtensions: ["ts", "tsx", "md", "mdx"],
   experimental: {
     turbopackUseSystemTlsCerts: true,
+    // Every route here is statically prerendered and only changes on deploy, so
+    // holding prefetched payloads longer than the 5min default stops a browsing
+    // session from re-requesting pages it already has.
+    staleTimes: {
+      static: 1800,
+      dynamic: 30,
+    },
   },
   turbopack: {
     root: "..",


### PR DESCRIPTION
next/link prefetches on viewport entry, and since every docs route is statically prerendered that means a full RSC payload per link. The sidebar renders 133 links and the mobile menu renders the same 133 again, so a single scroll could fire well over a hundred billable edge requests and effectively download the whole site.

Add a PrefetchLink wrapper that sets prefetch={false} and re-adds warming on hover, focus and touch via router.prefetch, deduped per page load. Plain prefetch={false} would also kill hover prefetching and make navigation feel slow, so warming on intent keeps clicks instant while only paying for routes the user actually aims at.

Also raise staleTimes.static to 30min — content only changes on deploy, so the 5min default was making sessions refetch pages they already had.

Measured on /docs/button: 140 internal links in the DOM against 21 requests of fixed per-pageview cost.

## Description
Brief description of what this PR does.

## Type of Change
- [ ] Bug fix
- [ ] New component
- [ ] Enhancement to existing component
- [ ] CLI change
- [ ] Documentation
- [ ] Other

## Component Checklist (if adding/modifying a component)
- [ ] Single file, under 80 lines
- [ ] Named export only (no default export)
- [ ] No `StyleSheet.create()` — NativeWind `className` only
- [ ] Imports `cn` from `@/lib/utils`
- [ ] `className` prop supported
- [ ] `...props` spread last
- [ ] `accessibilityRole` set on interactive elements
- [ ] Strict TypeScript — no `any` types
- [ ] Registry entry added in `cli/src/registry.ts`

## Testing
- [ ] `cd cli && npm test` passes
- [ ] Tested on iOS Simulator
- [ ] Tested on Android Emulator
- [ ] Dark mode works correctly

## Documentation
- [ ] Docs page created (if new component)
- [ ] Web preview component created (if new component)
- [ ] Sidebar/navbar updated (if new component)

## Screenshots
If applicable, add screenshots or GIFs showing the component.
