### PR TITLE
feat(docs): carry the AdSense tag and ads.txt for the whole domain

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
+import { ADSENSE_CLIENT } from "@/lib/ads";
+import { consentInitScript } from "@/lib/consent";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -69,6 +72,10 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon-light.ico" media="(prefers-color-scheme: light)" />
         <link rel="icon" href="/favicon-dark.ico" media="(prefers-color-scheme: dark)" />
+        {/* Ahead of the ad script below, which is the whole point of putting it
+            here: it is what stops a cookie being set in Europe in the moment
+            before Google's consent dialog has loaded. */}
+        <script dangerouslySetInnerHTML={{ __html: consentInitScript }} />
       </head>
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased font-sans`}>
         <ThemeProvider>
@@ -76,6 +83,15 @@ export default function RootLayout({
           {children}
           <Footer />
         </ThemeProvider>
+        {/* Verification for the whole aniui.dev domain, which is how AdSense
+            reaches academy.aniui.dev. No ad unit on this site consumes it. */}
+        <Script
+          id="adsbygoogle"
+          async
+          crossOrigin="anonymous"
+          strategy="afterInteractive"
+          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
+        />
       </body>
     </html>
   );

--- a/docs/lib/ads.ts
+++ b/docs/lib/ads.ts
@@ -1,0 +1,27 @@
+/**
+ * AdSense, for the domain rather than for this site.
+ *
+ * Nothing on aniui.dev is monetised and nothing here renders an ad unit. This
+ * exists because AdSense approves a *root domain* and every subdomain under it
+ * at once: the site being monetised is academy.aniui.dev, and the only way to
+ * get it approved is for aniui.dev to carry the tag and the ads.txt file. So
+ * the docs site is the one that gets verified and Academy is the one that
+ * earns.
+ *
+ * Two consequences worth knowing before changing anything here:
+ *
+ * - `public/ads.txt` has to stay on this domain. Crawling starts at the root,
+ *   and a subdomain's own ads.txt is only read when the root file names it with
+ *   a SUBDOMAIN line. Academy serves its own copy, and Google will never look
+ *   at it.
+ * - Auto ads must stay off in the dashboard. They apply to the whole domain,
+ *   subdomains included, and they choose their own placements — which sooner or
+ *   later means an ad inside Academy's exam room, beside the timer, on a paper
+ *   somebody paid for.
+ *
+ * The publisher ID is hardcoded rather than read from the environment because
+ * it is public — it ships in the script URL on every page of every AdSense site
+ * — and a verification tag that silently vanishes because a deploy is missing a
+ * variable is the exact failure this needs not to have.
+ */
+export const ADSENSE_CLIENT = "ca-pub-2679552542273749";

--- a/docs/lib/consent.ts
+++ b/docs/lib/consent.ts
@@ -1,0 +1,59 @@
+/**
+ * Consent defaults for Google's advertising tags.
+ *
+ * The AdSense script loads on this site for verification, which means it loads
+ * for European visitors too. No ad unit here requests an ad, so in practice it
+ * has little to set — but "in practice" is not the standard the EEA applies,
+ * and the cost of being right is six lines that run before the tag does.
+ *
+ * A mirror of the same file in AniUI Academy. The two sites are one domain as
+ * far as AdSense is concerned, so they should not disagree about this.
+ *
+ * The dialog itself is Google's, from the "Privacy & messaging" tab in AdSense:
+ * serving personalised ads to the EEA needs a *certified* CMP, which a banner
+ * written by hand would not be. These defaults only cover the gap before that
+ * CMP has loaded and answered, when an early tag would otherwise assume it may
+ * set whatever it likes.
+ */
+
+/** The EEA, plus the UK and Switzerland. */
+const CONSENT_REQUIRED_REGIONS = [
+  // EU member states
+  "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR",
+  "HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT", "NL", "PL", "PT", "RO",
+  "SE", "SI", "SK",
+  // The rest of the EEA
+  "IS", "LI", "NO",
+  // Not EEA, same requirement
+  "GB", "CH",
+] as const;
+
+/**
+ * Runs in `<head>`, ahead of any Google tag.
+ *
+ * `wait_for_update` holds Google's tags for 500ms in case a CMP is about to
+ * answer, rather than reading silence as refusal. Outside those regions the
+ * defaults are `granted`, which is a judgement about where consent is required
+ * up front and the line to move if that judgement changes.
+ */
+export const consentInitScript = `
+(function(){
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){window.dataLayer.push(arguments);}
+  window.gtag = window.gtag || gtag;
+  gtag('consent', 'default', {
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+    analytics_storage: 'denied',
+    region: ${JSON.stringify([...CONSENT_REQUIRED_REGIONS])},
+    wait_for_update: 500
+  });
+  gtag('consent', 'default', {
+    ad_storage: 'granted',
+    ad_user_data: 'granted',
+    ad_personalization: 'granted',
+    analytics_storage: 'granted'
+  });
+})();
+`.trim();

--- a/docs/public/ads.txt
+++ b/docs/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2679552542273749, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
AdSense approves a root domain and every subdomain beneath it in one go, so the application for academy.aniui.dev is really an application for aniui.dev — and the verification tag has to sit on the site Google fetches when it checks, which is this one. Nothing here is monetised and no ad unit is added; the docs site gets verified so that Academy can earn.

ads.txt has to live here for the same reason, and this is the part that is easy to get wrong. Crawling starts at the root domain, and a subdomain's own ads.txt is only read when the root file names it with a SUBDOMAIN line. Academy generates a perfectly good ads.txt at academy.aniui.dev/ads.txt that Google would never have looked at. One file at the root covers both sites, since both sell through the same publisher account.

The publisher ID is hardcoded rather than read from the environment. It is public — it ships in the script URL on every page of every AdSense site — and a verification tag that disappears because a deploy is missing a variable is precisely the failure this must not have.

Consent defaults come along because the tag loads for European visitors whether or not an ad ever renders. It mirrors Academy's copy, which matters: the two sites are one domain to AdSense and should not disagree about what a visitor has agreed to. The dialog itself stays Google's, since serving personalised ads to the EEA requires a certified CMP.

## Description
Brief description of what this PR does.

## Type of Change
- [ ] Bug fix
- [ ] New component
- [ ] Enhancement to existing component
- [ ] CLI change
- [ ] Documentation
- [ ] Other

## Component Checklist (if adding/modifying a component)
- [ ] Single file, under 80 lines
- [ ] Named export only (no default export)
- [ ] No `StyleSheet.create()` — NativeWind `className` only
- [ ] Imports `cn` from `@/lib/utils`
- [ ] `className` prop supported
- [ ] `...props` spread last
- [ ] `accessibilityRole` set on interactive elements
- [ ] Strict TypeScript — no `any` types
- [ ] Registry entry added in `cli/src/registry.ts`

## Testing
- [ ] `cd cli && npm test` passes
- [ ] Tested on iOS Simulator
- [ ] Tested on Android Emulator
- [ ] Dark mode works correctly

## Documentation
- [ ] Docs page created (if new component)
- [ ] Web preview component created (if new component)
- [ ] Sidebar/navbar updated (if new component)

## Screenshots
If applicable, add screenshots or GIFs showing the component.
