### PR TITLE
feat(docs): add Academy nav link with New badge

### DIFF
--- a/docs/components/navbar.tsx
+++ b/docs/components/navbar.tsx
@@ -111,6 +111,17 @@ export function Navbar() {
               Create
             </PrefetchLink>
             <a
+              href="https://academy.aniui.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-primary transition-colors hover:bg-primary/15"
+            >
+              Academy
+              <span className="rounded-full bg-primary px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-primary-foreground">
+                New
+              </span>
+            </a>
+            <a
               href="https://pro.aniui.dev"
               target="_blank"
               rel="noopener noreferrer"
@@ -159,6 +170,18 @@ export function Navbar() {
       {mobileOpen && (
         <div className="fixed inset-0 top-14 z-40 bg-background md:hidden overflow-y-auto">
           <nav className="space-y-4 p-6 pb-20">
+            <a
+              href="https://academy.aniui.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-3 py-2 text-sm font-medium text-primary"
+              onClick={() => setMobileOpen(false)}
+            >
+              Academy
+              <span className="rounded-full bg-primary px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-primary-foreground">
+                New
+              </span>
+            </a>
             <a
               href="https://pro.aniui.dev"
               target="_blank"


### PR DESCRIPTION
Add an Academy pill in the desktop and mobile navbars, matching the AniUI Pro styling and linking to https://academy.aniui.dev.

## Description
Brief description of what this PR does.

## Type of Change
- [ ] Bug fix
- [ ] New component
- [ ] Enhancement to existing component
- [ ] CLI change
- [ ] Documentation
- [ ] Other

## Component Checklist (if adding/modifying a component)
- [ ] Single file, under 80 lines
- [ ] Named export only (no default export)
- [ ] No `StyleSheet.create()` — NativeWind `className` only
- [ ] Imports `cn` from `@/lib/utils`
- [ ] `className` prop supported
- [ ] `...props` spread last
- [ ] `accessibilityRole` set on interactive elements
- [ ] Strict TypeScript — no `any` types
- [ ] Registry entry added in `cli/src/registry.ts`

## Testing
- [ ] `cd cli && npm test` passes
- [ ] Tested on iOS Simulator
- [ ] Tested on Android Emulator
- [ ] Dark mode works correctly

## Documentation
- [ ] Docs page created (if new component)
- [ ] Web preview component created (if new component)
- [ ] Sidebar/navbar updated (if new component)

## Screenshots
If applicable, add screenshots or GIFs showing the component.
